### PR TITLE
Fix bug where 10 hits was actually 12

### DIFF
--- a/Nez.Samples/Scenes/Ninja Adventure/ProjectileHitDetector.cs
+++ b/Nez.Samples/Scenes/Ninja Adventure/ProjectileHitDetector.cs
@@ -24,13 +24,13 @@ namespace Nez.Samples
 		
 		void ITriggerListener.onTriggerEnter( Collider other, Collider self )
 		{
-			if( _hitCounter > hitsUntilDead )
+			_hitCounter++;
+			if (_hitCounter >= hitsUntilDead)
 			{
 				entity.destroy();
 				return;
 			}
 
-			_hitCounter++;
 			_sprite.color = Color.Red;
 			Core.schedule( 0.1f, timer => _sprite.color = Color.White );
 		}

--- a/Nez.Samples/Scenes/Ninja Adventure/ProjectileHitDetector.cs
+++ b/Nez.Samples/Scenes/Ninja Adventure/ProjectileHitDetector.cs
@@ -25,7 +25,7 @@ namespace Nez.Samples
 		void ITriggerListener.onTriggerEnter( Collider other, Collider self )
 		{
 			_hitCounter++;
-			if (_hitCounter >= hitsUntilDead)
+			if ( _hitCounter >= hitsUntilDead )
 			{
 				entity.destroy();
 				return;


### PR DESCRIPTION
There was a small bug where it took 12 hits to destroy the moon.  Updating the hit counter before the check and checking for `>=` because the counter starts at 0.

Now it takes the specified 10 hits.  :smile: