### PR TITLE
MonoGameOrange doesn't exist in FNA

### DIFF
--- a/Nez.Samples/SampleHelpers/SampleScene.cs
+++ b/Nez.Samples/SampleHelpers/SampleScene.cs
@@ -75,7 +75,7 @@ namespace Nez.Samples
 			var checkbox = _table.add( new CheckBox( "Debug Render", new CheckBoxStyle
 			{
 				checkboxOn = new PrimitiveDrawable( 30, Color.Green ),
-				checkboxOff = new PrimitiveDrawable( 30, Color.MonoGameOrange )
+				checkboxOff = new PrimitiveDrawable( 30, new Color( 0x00, 0x3c, 0xe7, 0xff ) )
 			} ) ).getElement<CheckBox>();
 			checkbox.onChanged += enabled => Core.debugRenderEnabled = enabled;
 			checkbox.isChecked = Core.debugRenderEnabled;


### PR DESCRIPTION
When trying to get the samples to run in FNA, this failed.  So the color was replaced with the hex code from the MonoGame source.