### PR TITLE
Add missing columns attribute to tilemaps

### DIFF
--- a/Nez.Samples/Content/AnimatedTiles/desert-palace.tmx
+++ b/Nez.Samples/Content/AnimatedTiles/desert-palace.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="32" height="28" tilewidth="8" tileheight="8">
- <tileset firstgid="1" name="desert-palace" tilewidth="8" tileheight="8">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="32" height="28" tilewidth="8" tileheight="8" nextobjectid="1">
+ <tileset firstgid="1" name="desert-palace" tilewidth="8" tileheight="8" tilecount="256" columns="16">
   <image source="desert-palace-tiles.png" width="128" height="128"/>
   <tile id="64">
    <animation>
@@ -27,7 +27,7 @@
    </animation>
   </tile>
  </tileset>
- <tileset firstgid="257" name="lamp" tilewidth="16" tileheight="16">
+ <tileset firstgid="257" name="lamp" tilewidth="16" tileheight="16" tilecount="4" columns="2">
   <image source="desert-palace-lamp.png" width="32" height="32"/>
   <tile id="0">
    <animation>

--- a/Nez.Samples/Content/DestructableMap/destructable-map.tmx
+++ b/Nez.Samples/Content/DestructableMap/destructable-map.tmx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="left-down" width="40" height="23" tilewidth="16" tileheight="16" nextobjectid="4">
- <tileset firstgid="1" name="desert-palace-tiles2x" tilewidth="16" tileheight="16" tilecount="256">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="left-down" width="40" height="23" tilewidth="16" tileheight="16" nextobjectid="4">
+ <tileset firstgid="1" name="desert-palace-tiles2x" tilewidth="16" tileheight="16" tilecount="256" columns="16">
   <image source="desert-palace-tiles2x.png" width="256" height="256"/>
   <tile id="8">
    <properties>


### PR DESCRIPTION
I saved the sample tilemaps with Tiled 1.0.3 so the columns attribute would get added.  This fixes the exception seen in #18 