### PR TITLE
Include All Content in FNA builds

### DIFF
--- a/Nez.Samples/Nez.FNA.Samples.csproj
+++ b/Nez.Samples/Nez.FNA.Samples.csproj
@@ -41,20 +41,12 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
 
-	    <!-- Include the Content directory svg files -->
-        <Content Include="Content/**/*.svg">
+    <!-- Include the Content directory (except for .fx files, since we use .fxb at runtime) -->
+    <ItemGroup>
+        <Content Include="Content\**\*" Exclude="**\*.fx">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-		
-	    <!-- Include Particle Designer files -->
-        <Content Include="Content/ParticleDesigner/*">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
-		
-	    <!-- Tmx and png files -->
-        <Content Include="Content/**/*.tmx;Content/**/*.png">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
+    </ItemGroup>
 		
 		<!-- Include the Content bin (MGCB output). Copy it to the Content folder in the build. -->
         <Content Include="Content/bin/DesktopGL/Content/**">

--- a/Nez.Samples/Nez.FNA.Samples.csproj
+++ b/Nez.Samples/Nez.FNA.Samples.csproj
@@ -42,11 +42,9 @@
         </Content>
 
     <!-- Include the Content directory (except for .fx files, since we use .fxb at runtime) -->
-    <ItemGroup>
         <Content Include="Content\**\*" Exclude="**\*.fx">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
-    </ItemGroup>
 		
 		<!-- Include the Content bin (MGCB output). Copy it to the Content folder in the build. -->
         <Content Include="Content/bin/DesktopGL/Content/**">


### PR DESCRIPTION
Not sure why this differs from the MG* csproj's, but building this project on FNA meant the Plume.tga from Ninja scene was not being copied into the output folder. I copied over the same rule that was in the MG csproj.